### PR TITLE
🔧fix: exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
   "devDependencies": {
     "@types/node": "^20.1.4",
     "bun-types": "^0.5.8",
-    "elysia": "0.5.0",
+    "elysia": "0.5.12",
     "eslint": "^8.40.0",
     "mitata": "^0.1.6",
     "rimraf": "4.3",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "elysia": ">= 0.5.0"
+    "elysia": ">= 0.5.12"
   },
   "exports": {
+    "node": "./dist/cjs/index.js",
     "require": "./dist/cjs/index.js",
     "import": "./dist/index.js",
-    "node": "./dist/index.js",
     "default": "./dist/index.js"
   },
   "bugs": "https://github.com/elysiajs/elysia-static/issues",
@@ -40,7 +40,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "bun run --hot example/index.ts",
-    "test": "bun wiptest",
+    "test": "bun wiptest && npm run test:node",
+    "test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js",
     "build": "rimraf dist && tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
     "release": "npm run build && npm run test && npm publish --access public"
   },

--- a/test/node/.gitignore
+++ b/test/node/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/test/node/cjs/index.js
+++ b/test/node/cjs/index.js
@@ -1,0 +1,11 @@
+if ('Bun' in globalThis) {
+  throw new Error('❌ Use Node.js to run this test!');
+}
+
+const { staticPlugin } = require('@elysiajs/static');
+
+if (typeof staticPlugin !== 'function') {
+  throw new Error('❌ CommonJS Node.js failed');
+}
+
+console.log('✅ CommonJS Node.js works!');

--- a/test/node/cjs/package.json
+++ b/test/node/cjs/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "commonjs",
+    "dependencies": {
+        "@elysiajs/static": "../../.."
+    }
+}

--- a/test/node/esm/index.js
+++ b/test/node/esm/index.js
@@ -1,0 +1,11 @@
+if ('Bun' in globalThis) {
+  throw new Error('❌ Use Node.js to run this test!');
+}
+
+import { staticPlugin } from '@elysiajs/static';
+
+if (typeof staticPlugin !== 'function') {
+  throw new Error('❌ ESM Node.js failed');
+}
+
+console.log('✅ ESM Node.js works!');

--- a/test/node/esm/package.json
+++ b/test/node/esm/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "dependencies": {
+        "@elysiajs/static": "../../.."
+    }
+}


### PR DESCRIPTION
- Fixed `exports` in `package.json` as mentioned in https://github.com/elysiajs/elysia/issues/50
- I updated `Elysia.js` to `0.5.12` because the previous version includes `memoirist` that does not support CommonJS
- Added tests for `CJS` & `ESM` under `Node.js`