### PR TITLE
fix: always static with assets on an absolute path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
                       })
                 : () => new Response(Bun.file(file))
 
-            let fileName = file.replace(resolve(), '').replace(`${assets}/`, '')
+            let fileName = file.replace(resolve(), '').replace(`${assets}/`.replace(resolve(), ''), '')
 
             if (noExtension) {
                 const temp = fileName.split('.')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,7 @@ import { Elysia } from 'elysia'
 import { staticPlugin } from '../src'
 
 import { describe, expect, it } from 'bun:test'
+import { join } from "path";
 
 const req = (path: string) => new Request(`http://localhost${path}`)
 
@@ -134,6 +135,21 @@ describe('Static Plugin', () => {
             .then((r) => r.text())
 
         expect(res).toBe(takodachi)
+    })
+
+    it('always static with assets on an absolute path', async () => {
+        const app = new Elysia().use(
+            staticPlugin({
+                alwaysStatic: true,
+                assets: join(import.meta.dir, '../public')
+            })
+        )
+
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi.png'))
+        const blob = await res.blob()
+        expect(await blob.text()).toBe(takodachi)
     })
 
     it('exclude extension', async () => {


### PR DESCRIPTION
On a monorepo, my assets live on a subdirectory that is oblivious to the root of the project, hence I needed to specify an absolute path for the assets.

It works fine when `alwaysStatic` is `false`, but fails when `true`. This PR addresses this issue.