### PR TITLE
feat: add maxAge param to Cache-Control header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
         resolve = resolveFn,
         headers = {},
         noCache = false,
+        maxAge = 0,
         indexHTML = true
     }: {
         /**
@@ -120,6 +121,15 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
          * If set to true, browser caching will be disabled
          */
         noCache?: boolean
+        /**
+         * @default 0
+         *
+         * Specifies the maximum amount of time in seconds, a resource will be considered fresh.
+         * This freshness lifetime is calculated relative to the time of the request.
+         * This setting helps control browser caching behavior.
+         * A `maxAge` of 0 will prevent caching, requiring requests to validate with the server before use.
+         */
+        maxAge?: number
         /**
          * @default true
          *
@@ -206,7 +216,7 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
                           }
 
                           headers['Etag'] = etag
-                          headers['Cache-Control'] = 'public, max-age=0'
+                          headers['Cache-Control'] = `public, max-age=${maxAge}`
 
                           return new Response(file, {
                               headers
@@ -230,7 +240,8 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
                               }
 
                               headers['Etag'] = etag
-                              headers['Cache-Control'] = 'public, max-age=0'
+                              headers['Cache-Control'] =
+                                  `public, max-age=${maxAge}`
 
                               return new Response(file, {
                                   headers
@@ -312,7 +323,7 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
                             })
 
                         headers['Etag'] = etag
-                        headers['Cache-Control'] = 'public, max-age=0'
+                        headers['Cache-Control'] = `public, max-age=${maxAge}`
 
                         return new Response(file, {
                             headers

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -243,6 +243,39 @@ describe('Static Plugin', () => {
         expect(res.status).toBe(200)
     })
 
+    it('return Cache-Control header when maxAge is set', async () => {
+        const app = new Elysia().use(
+            staticPlugin({
+                alwaysStatic: true,
+                noExtension: true,
+                maxAge: 3600
+            })
+        )
+
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi'))
+
+        expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600')
+        expect(res.status).toBe(200)
+    })
+
+    it('return Cache-Control header when maxAge is not set', async () => {
+        const app = new Elysia().use(
+            staticPlugin({
+                alwaysStatic: true,
+                noExtension: true
+            })
+        )
+
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi'))
+
+        expect(res.headers.get('Cache-Control')).toBe('public, max-age=0')
+        expect(res.status).toBe(200)
+    })
+
     it('return not modified response (etag)', async () => {
         const app = new Elysia().use(
             staticPlugin({


### PR DESCRIPTION
It takes advantage of the Etag + Cache-Control setup

<img width="717" alt="image" src="https://github.com/elysiajs/elysia-static/assets/27580836/345ebcf0-1834-4e44-b07c-505ff9680eb1">

Changes in the API: 
```diff
  export const app = new Elysia()
    .use(
      staticPlugin({
        prefix: '',
-        headers: {
-          'Cache-Control': 'public, max-age=86400',
-        },
+       maxAge: 86400
      })
    )
```