### PR TITLE
fix: support system paths (windows)

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia'
 import { staticPlugin } from '../src'
 
 import { describe, expect, it } from 'bun:test'
-import { join } from 'path'
+import { join, sep } from 'path'
 
 const req = (path: string) => new Request(`http://localhost${path}`)
 
@@ -98,7 +98,7 @@ describe('Static Plugin', () => {
     it('ignore string pattern', async () => {
         const app = new Elysia({ forceErrorEncapsulation: true }).use(
             staticPlugin({
-                ignorePatterns: ['public/takodachi.png']
+                ignorePatterns: [`public${sep}takodachi.png`]
             })
         )
 


### PR DESCRIPTION
With bun on windows arriving, the static plugin for Elysia needs some minor fixes where the assumption was made that the url path separator would match the system separator.

**Problem:** When using `alwaysStatic`, servers run on windows with this plugin have invalid paths generated and added to the router, such as: `/public/images\sample.png`.

**Background:** The plugin at initialization time when either in production with sufficiently few static files or when alwaysStatic is set to `true` uses `readdir` to find the names of files to serve. The names are the full paths for the files, and are returned using the operating system’s native separator (on windows this is `\`. This has cascading effects through the plugin when run on windows, because the plugin assumes a *NIX style `/`, which was fine until bun released windows support. 

**Solution:** Identified areas of the code reliant on `/` and added compatibility for windows’ and any other future native path separators.

Tested by running suite on windows + exploring with the example.