### PR TITLE
Fixed edge case when working dir is root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ export const staticPlugin = async <Prefix extends string = '/prefix'>(
         }
     })
 
-    const assetsDir = assets[0] === sep ? assets : resolve() + sep + assets
+    const assetsDir = assets[0] === sep ? assets : resolve(assets)
 
     if (
         alwaysStatic ||


### PR DESCRIPTION
This PR fixes an edge case where if the current working dir is root `/` and the assets path is relative. The assets path currently gets expanded to `//[assets]` and not normalized, which causes 404 errors on the assets.

The path.resolve([...paths]) takes care of creating an absolute path and normalizing it (deduplicates consecutive separators, but also resolves `.` and `..`), instead of doing a manual join.