### PR TITLE
feat: Add bundleHTML option for HTML file handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
     etag: useETag = true,
     extension = true,
     indexHTML = true,
+    bundleHTML = true,
     decodeURI,
     silent
 }: StaticOptions<Prefix> = {}): Promise<Elysia> {
@@ -87,13 +88,13 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
                 let pathName = normalizePath(path.join(prefix, relativePath))
 
                 if (isBun && absolutePath.endsWith('.html')) {
-                    const htmlBundle = await import(absolutePath)
+                    const htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
 
-                    app.get(pathName, htmlBundle.default)
+                    app.get(pathName, htmlFile)
                     if (indexHTML && pathName.endsWith('/index.html'))
                         app.get(
                             pathName.replace('/index.html', ''),
-                            htmlBundle.default
+                            htmlFile
                         )
 
                     continue
@@ -233,13 +234,13 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
 
                 let relativePath = absolutePath.replace(assetsDir, '')
                 const pathName = normalizePath(path.join(prefix, relativePath))
-                const htmlBundle = await import(absolutePath)
+                const htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
 
-                app.get(pathName, htmlBundle.default)
+                app.get(pathName, htmlFile)
                 if (indexHTML && pathName.endsWith('/index.html'))
                     app.get(
                         pathName.replace('/index.html', ''),
-                        htmlBundle.default
+                        htmlFile
                     )
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,17 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
                 let pathName = normalizePath(path.join(prefix, relativePath))
 
                 if (isBun && absolutePath.endsWith('.html')) {
-                    const htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
+                    let htmlFile
+                    try {
+                        htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
+                    } catch (error) {
+                        if (!silent)
+                            console.error(
+                                `[@elysiajs/static] Failed to load HTML file: ${absolutePath}`,
+                                error
+                            )
+                        continue
+                    }
 
                     app.get(pathName, htmlFile)
                     if (indexHTML && pathName.endsWith('/index.html'))
@@ -234,7 +244,17 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
 
                 let relativePath = absolutePath.replace(assetsDir, '')
                 const pathName = normalizePath(path.join(prefix, relativePath))
-                const htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
+                let htmlFile
+                try {
+                    htmlFile = bundleHTML ? (await import(absolutePath)).default : getFile(absolutePath)
+                } catch (error) {
+                    if (!silent)
+                        console.error(
+                            `[@elysiajs/static] Failed to load HTML file: ${absolutePath}`,
+                            error
+                        )
+                    continue
+                }
 
                 app.get(pathName, htmlFile)
                 if (indexHTML && pathName.endsWith('/index.html'))

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,13 @@ export interface StaticOptions<Prefix extends string> {
     indexHTML?: boolean
 
     /**
+     * @default true
+     *
+     * Enable bun bundle of *.html
+     */
+	bundleHTML?: boolean
+
+    /**
      * decodeURI
      *
      * @default false

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,9 @@ export interface StaticOptions<Prefix extends string> {
     /**
      * @default true
      *
-     * Enable bun bundle of *.html
+     * Enable bundling of HTML files (Bun only).
+     * When true, HTML imports using Bun’s bundler, JavaScript transpiler and CSS parser. [See more](https://bun.com/docs/bundler/fullstack)
+     * When false, HTML files are served directly from disk.
      */
 	bundleHTML?: boolean
 


### PR DESCRIPTION
#54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public option to toggle HTML bundling (default: enabled) to control whether HTML is loaded as bundled modules or served directly.

* **Bug Fixes**
  * More resilient HTML loading: errors are logged (unless silenced) and processing continues to avoid blocking routes.
  * Consistent bundling behavior applied across environments, including index HTML handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->