### PR TITLE
fix: resolve wildcard path against assetsDir before read

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,14 +299,15 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
         app.onError(() => {}).get(
             `${prefix.endsWith('/') ? prefix.slice(0, -1) : prefix}/*`,
             async ({ params, headers: requestHeaders }) => {
-                const pathName = normalizePath(
-                    path.join(
-                        assets,
-                        decodeURI
-                            ? (fastDecodeURI(params['*']) ?? params['*'])
-                            : params['*']
-                    )
-                )
+                const userPart = decodeURI
+                    ? (fastDecodeURI(params['*']) ?? params['*'])
+                    : params['*']
+
+                const joined = path.resolve(assetsDir, userPart)
+                if (joined !== assetsDir && !joined.startsWith(assetsDir + path.sep))
+                    throw new NotFoundError()
+
+                const pathName = normalizePath(joined)
 
                 if (shouldIgnore(pathName)) throw new NotFoundError()
 


### PR DESCRIPTION
currently, the handler uses `path.join(assets, params['*'])` and relies on the joined path staying within the assets directory. since `params['*']` is a raw string from the router, `path.join` can resolve `..` segments in a way that produces paths outside `assets` depending on the input. fortunately this doesn't happen with normal browser usage, but it can be triggered by editing the packets. also, **this is exclusively for development mode. the same wouldn't work on production mode.**

this switches to `path.resolve(assetsDir, userPart)` and adds an explicit check that the resolved path is either `assetsDir` itself or a descendant of it. if it isn't, we fall through to `NotFoundError()`, the same behavior the handler already uses for missing files and ignored patterns.

behavior should not change for valid requests!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file path validation to prevent unauthorized directory traversal and access to files outside the designated asset directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->