### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # @elysiajs/static
-Plugin for [elysia](https://github.com/saltyaom/elysia) for serving static folder.
+Plugin for [elysia](https://github.com/elysiajs/elysia) for serving static folder.
 
 ## Installation
 ```bash


### PR DESCRIPTION
Hyperlink for elysia in the README.md links to https://github.com/saltyaom/elysia resolves to a 404 page not found.
<img width="1736" height="530" alt="image" src="https://github.com/user-attachments/assets/15589c1f-f67f-443f-b7fe-f8a15c3da76c" />

With fix, the hyperlink links to https://github.com/elysiajs/elysia, which is the desired behavior.
<img width="1736" height="530" alt="image" src="https://github.com/user-attachments/assets/1aac0fd8-37cb-4e82-846b-4b0782be9a53" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s one-line hyperlink to point to the main project repository. This is a documentation-only change—no examples, configuration, exported APIs, or code were modified. The update clarifies the referenced project source and improves link accuracy for readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->