### PR TITLE
fix: relative path resolution for the assets directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import fastDecodeURI from 'fast-decode-uri-component'
 import {
     LRUCache,
     fileExists,
+    findProjectRoot,
     getBuiltinModule,
     listFiles,
     generateETag,
@@ -63,8 +64,11 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
         try {
             const bun = await import('bun')
 
-            if (typeof bun.main === 'string')
-                return path.dirname(path.dirname(bun.main))
+            if (typeof bun.main === 'string') {
+                const root = await findProjectRoot(bun.main)
+                if (root) return root
+                return path.dirname(bun.main)
+            }
         } catch {}
 
         return process.cwd()

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,14 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
 
     const fileCache = new LRUCache<string, Response>()
 
+    /**
+     * Returns the directory used as the base for resolving relative assets paths.
+     *
+     * In Bun, prefer the project root that owns the executed entrypoint so
+     * `assets: "public"` is stable even when the process is started from a
+     * different current working directory. Falls back to `process.cwd()` for
+     * non-Bun runtimes or when the entrypoint cannot be resolved.
+     */
     const getDefaultAssetsBase = async () => {
         if (!isBun) return process.cwd()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,16 +57,44 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
 
     const fileCache = new LRUCache<string, Response>()
 
+    const getDefaultAssetsBase = async () => {
+        if (!isBun) return process.cwd()
+
+        try {
+            const bun = await import('bun')
+
+            if (typeof bun.main === 'string')
+                return path.dirname(path.dirname(bun.main))
+        } catch {}
+
+        return process.cwd()
+    }
+
     if (prefix === path.sep) prefix = '' as Prefix
-    const assetsDir = path.resolve(assets)
+    const assetsDir = path.isAbsolute(assets)
+        ? path.resolve(assets)
+        : path.resolve(await getDefaultAssetsBase(), assets)
+    
     const shouldIgnore = !ignorePatterns.length
         ? () => false
-        : (file: string) =>
-              ignorePatterns.find((pattern) =>
-                  typeof pattern === 'string'
-                      ? pattern.includes(file)
-                      : pattern.test(file)
-              )
+        : (file: string) => {
+            const normalizedFile = normalizePath(file)
+            const relativeFile = normalizePath(
+                path.relative(assetsDir, file)
+            )
+
+            return ignorePatterns.find((pattern) => {
+                if (typeof pattern !== 'string')
+                    return pattern.test(normalizedFile) || pattern.test(relativeFile)
+
+                const normalizedPattern = normalizePath(pattern)
+
+                return (
+                    normalizedFile.includes(normalizedPattern) ||
+                    relativeFile.includes(normalizedPattern)
+                )
+            })
+        }
 
     const app = new Elysia({
         name: 'static',
@@ -74,7 +102,7 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
     })
 
     if (alwaysStatic) {
-        const files = await listFiles(path.resolve(assets))
+        const files = await listFiles(assetsDir)
 
         if (files.length <= staticLimit)
             for (const absolutePath of files) {
@@ -261,7 +289,7 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
         !(`GET_${prefix}/*` in app.routeTree)
     ) {
         if (isBun) {
-            const htmls = await listHTMLFiles(path.resolve(assets))
+            const htmls = await listHTMLFiles(assetsDir)
 
             for (const absolutePath of htmls) {
                 if (!absolutePath || shouldIgnore(absolutePath)) continue
@@ -301,7 +329,7 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
             async ({ params, headers: requestHeaders }) => {
                 const pathName = normalizePath(
                     path.join(
-                        assets,
+                        assetsDir,
                         decodeURI
                             ? (fastDecodeURI(params['*']) ?? params['*'])
                             : params['*']

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,13 @@ export function fileExists(path: string) {
     )
 }
 
+/**
+ * Walks upward from an entrypoint file and returns the nearest directory
+ * containing a package.json.
+ *
+ * This is used to infer the application project root from Bun's entrypoint
+ * instead of relying only on process.cwd().
+ */
 export const findProjectRoot = async (
     entrypoint: string
 ): Promise<string | null> => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,25 @@ export function fileExists(path: string) {
     )
 }
 
+export const findProjectRoot = async (
+    entrypoint: string
+): Promise<string | null> => {
+    if (!fs) getBuiltinModule()
+
+    let dir = path.dirname(entrypoint)
+
+    while (true) {
+        try {
+            await fs.stat(path.join(dir, 'package.json'))
+            return dir
+        } catch {}
+
+        const parent = path.dirname(dir)
+        if (parent === dir) return null
+        dir = parent
+    }
+}
+
 export class LRUCache<K, V> {
     private map = new Map<K, [V, number]>()
     private interval: number | undefined

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,14 @@
 import { Elysia } from 'elysia'
 import { staticPlugin } from '../src'
+import { findProjectRoot } from '../src/utils'
 
 import { describe, expect, it } from 'bun:test'
 import { join, sep } from 'path'
 import path from 'path'
 
 import { req, takodachi } from './utils'
+
+const __dirname = import.meta.dir
 
 describe('Static Plugin', () => {
     it('should get root path', async () => {
@@ -493,5 +496,36 @@ describe('relative assets path resolution (issue #58)', () => {
 
         const res = await app.handle(req('/public/takodachi.png'))
         expect(res.status).toBe(200)
+    })
+})
+
+describe('findProjectRoot', () => {
+    it('finds package.json walking up from a deep entrypoint', async () => {
+        const repoRoot = path.resolve(__dirname, '..')
+        const syntheticEntrypoint = path.join(repoRoot, 'src', 'index.ts')
+
+        const result = await findProjectRoot(syntheticEntrypoint)
+        expect(result).toBe(repoRoot)
+    })
+
+    it('finds package.json from a flat-layout entrypoint at the project root', async () => {
+        const repoRoot = path.resolve(__dirname, '..')
+        const flatEntrypoint = path.join(repoRoot, 'index.ts')
+
+        const result = await findProjectRoot(flatEntrypoint)
+        expect(result).toBe(repoRoot)
+    })
+
+    it('finds package.json from a deeper layout', async () => {
+        const repoRoot = path.resolve(__dirname, '..')
+        const deepEntrypoint = path.join(repoRoot, 'apps', 'web', 'src', 'server.ts')
+
+        const result = await findProjectRoot(deepEntrypoint)
+        expect(result).toBe(repoRoot)
+    })
+
+    it('returns null when no package.json is found above the entrypoint', async () => {
+        const result = await findProjectRoot('/tmp/no-such-project/index.ts')
+        expect(result).toBeNull()
     })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -485,7 +485,7 @@ describe('relative assets path resolution (issue #58)', () => {
         expect(res.status).toBe(200)
     })
 
-    it('serves files when cwd differs from project root', async () => {
+    it.serial('serves files when cwd differs from project root', async () => {
         const originalCwd = process.cwd()
         const tempDir = path.join(originalCwd, '..')
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -122,6 +122,19 @@ describe('Static Plugin', () => {
         expect(file.status).toBe(404)
     })
 
+    it('ignores when pattern is a substring of the file path', async () => {
+        const app = new Elysia().use(
+            staticPlugin({
+                ignorePatterns: ['takodachi']
+            })
+        )
+
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi.png'))
+        expect(res.status).toBe(404)
+    })
+
     it('always static', async () => {
         const app = new Elysia().use(
             staticPlugin({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,6 +3,7 @@ import { staticPlugin } from '../src'
 
 import { describe, expect, it } from 'bun:test'
 import { join, sep } from 'path'
+import path from 'path'
 
 import { req, takodachi } from './utils'
 
@@ -456,5 +457,41 @@ describe('Static Plugin', () => {
         for (const route of app.routes) {
             expect(route.hooks.detail.hide).toBeFalse()
         }
+    })
+})
+
+describe('relative assets path resolution (issue #58)', () => {
+    it('serves files using default relative assets path', async () => {
+        const app = new Elysia().use(staticPlugin())
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi.png'))
+        expect(res.status).toBe(200)
+    })
+
+    it('serves files when cwd differs from project root', async () => {
+        const originalCwd = process.cwd()
+        const tempDir = path.join(originalCwd, '..')
+
+        try {
+            process.chdir(tempDir)
+
+            const app = new Elysia().use(staticPlugin())
+            await app.modules
+
+            const res = await app.handle(req('/public/takodachi.png'))
+            expect(res.status).toBe(200)
+        } finally {
+            process.chdir(originalCwd)
+        }
+    })
+
+    it('serves files when assets is an absolute path', async () => {
+        const absoluteAssets = path.resolve(process.cwd(), 'public')
+        const app = new Elysia().use(staticPlugin({ assets: absoluteAssets }))
+        await app.modules
+
+        const res = await app.handle(req('/public/takodachi.png'))
+        expect(res.status).toBe(200)
     })
 })


### PR DESCRIPTION
Attempts to resolve #58.

## Main issue

Relative assets paths were previously resolved from `process.cwd()`.

That worked when the server was started from the project root, but failed when the same entrypoint was started from another working directory, for example:

```
cd ..
bun run project/src/index.ts
```

In that case, assets: `public` was resolved as `../public` instead of `project/public`, causing static asset requests to fail with `ENOENT`.

## Changes

- Resolve relative assets paths from the Bun entrypoint’s project root when available.
- Preserve support for absolute assets paths.
- Use the resolved `assetsDir` consistently across:
  - eager static asset registration
  - HTML asset discovery
  - dynamic wildcard static serving
- Add project-root discovery by walking upward from the Bun entrypoint until `package.json` is found.
- Fall back to the entrypoint directory when no `package.json` can be found.
- Fall back to `process.cwd()` when Bun entrypoint metadata is unavailable.
- Update `shouldIgnore` so ignore string patterns continue to work after asset paths are resolved to absolute paths.

## Additional test coverage added by JoshuaNam

- Added regression coverage for relative assets path resolution:
  - default relative assets path serves files
  - relative assets path still works when cwd differs from the project root
  - absolute assets path continues to serve files correctly

- Added unit coverage for findProjectRoot:
  - finds `package.json` from a deep entrypoint
  - finds `package.json` from a flat-layout entrypoint at the project root
  - finds `package.json` from a deeper app-style layout
  - returns null when no `package.json` exists above the entrypoint

- Added ignore-pattern regression coverage:
  - partial string ignore patterns still match file paths after internal path resolution changes

## Notes

### Notes on project-root resolution

The fix now prefers the nearest package.json above the Bun entrypoint, which is more robust than assuming a fixed directory depth from bun.main.

This avoids resolving assets relative to the wrong cwd while still supporting different project layouts, including flat entrypoints and deeper src/app structures.

### Notes on `shouldIgnore`

The `shouldIgnore` update is required because `assetsDir` may now be absolute internally. Without adjusting the ignore matching behavior, existing string ignore patterns could stop matching user-provided relative-style patterns.

## Testing

- Existing and newly added tests pass with:

bun test

- Current coverage includes:
  - relative assets path behavior
  - cwd mismatch behavior
  - absolute assets path behavior
  - project root discovery
  - partial-string ignore pattern matching

### Manual verification

I also manually tested the startup path behavior by temporarily adding:

```
new Elysia()
    .use(staticPlugin())
    .listen(3000)
```

at the end of `src/index.ts`, then starting the server from different current working directories.

With the current changes, relative assets paths no longer produced `ENOENT` when the entrypoint was launched from outside the project root.

## Compatibility

This preserves the existing public API:

```
staticPlugin({
    assets: "public"
})
```

No user configuration changes should be required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assets directory resolution when using relative asset paths (improves serving under alternate runtimes and when cwd differs from project root)
  * Improved ignore-pattern matching with path normalization so ignored files are consistently filtered
  * Standardized static file enumeration and path handling to reduce incorrect 404s

* **Tests**
  * Added tests covering asset resolution and ignore-pattern behavior across configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->