### PR TITLE
Fix: add bundleHTML param back

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Below is an available config for a static plugin.
 
 Asset path to expose as a public path
 
+### ignorePatterns
+@default []
+
+List of files to ignore from serving as static files
+
 ### prefix
 @default '/public'
 
@@ -37,6 +42,69 @@ If total files exceed this number, the file will be handled via wildcard instead
 ### alwaysStatic
 @default boolean
 
-If set to true, the file will always use a static path instead
+If set to true, the plugin will mount around at most `staticLimit` routes before defaulting to wildcard. If false, all routes will go under the wildcard route, with the exclusion of any HTML files bundled by Bun.
+
+### ignorePatterns
+@default [] `Array<string | RegExp>`
+
+Array of file to ignore publication. If one of the patters is matched, file will not be exposed.
+
+### extension
+@default true
+
+Indicates if file extension is required in URL request
+
+Only works if `alwaysStatic` is set to true
+
+### headers
+@default {}
+
+Set response headers of files
+
+### etag
+@default true
+
+If set to false, browser caching will be disabled
+
+### directive
+
+@default public
+
+directive for Cache-Control header
+
+@see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#directives
+
+### maxAge
+
+@default 86400
+
+Specifies the maximum amount of time in seconds, a resource will be considered fresh.
+This freshness lifetime is calculated relative to the time of the request.
+This setting helps control browser caching behavior.
+A `maxAge` of 0 will prevent caching, requiring requests to validate with the server before use.
+ 
+
+### indexHTML
+@default false
+
+If set to true, any index.html file served at https://host.com/\*\*/index.html will also be served at https://host.com/\*\*
 
 See [documentation](https://elysiajs.com/plugins/static) for more details.
+
+### bunFullstack
+
+Enable bundling of HTML files (Bun only).
+When true, HTML imports using Bun’s bundler, JavaScript transpiler and CSS parser. [See more](https://bun.com/docs/bundler/fullstack)
+When false, HTML files are served directly from disk.
+
+### decodeURI
+@default false
+
+### detail
+
+specify OpenAPI spec configuration for static routes
+
+### silent
+@default false
+
+If set to true, suppresses all logs and warnings from the static plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
     extension = true,
     indexHTML = true,
     detail,
-    bunFullstack = false,
+    bundleHTML = true,
+    bunFullstack,
     decodeURI,
     silent
 }: StaticOptions<Prefix> = {}): Promise<Elysia> {
@@ -50,6 +51,9 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
             )
 
         return new Elysia()
+    }
+    if (bunFullstack === undefined) {
+        bunFullstack = bundleHTML
     }
 
     const builtinModule = getBuiltinModule()

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,16 @@ export interface StaticOptions<Prefix extends string> {
     indexHTML?: boolean
 
     /**
+     * @default true
+     * @deprecated use `bunFullstack` instead
+     *
+     * Enable bundling of HTML files (Bun only). Setting `bunFullstack` will override this property
+     * When true, HTML imports using Bun’s bundler, JavaScript transpiler and CSS parser. [See more](https://bun.com/docs/bundler/fullstack)
+     * When false, HTML files are served directly from disk.
+     */
+    bundleHTML?: boolean
+
+    /**
      * @default false
      *
      * Enable bundling of HTML files (Bun only).

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,8 +114,6 @@ export interface StaticOptions<Prefix extends string> {
     bundleHTML?: boolean
 
     /**
-     * @default false
-     *
      * Enable bundling of HTML files (Bun only).
      * When true, HTML imports using Bun’s bundler, JavaScript transpiler and CSS parser. [See more](https://bun.com/docs/bundler/fullstack)
      * When false, HTML files are served directly from disk.

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,10 @@ export interface StaticOptions<Prefix extends string> {
     /**
      * @default false unless `NODE_ENV` is 'production'
      *
-     * Should file always be served statically (note: if bunFullstack is set to true, any html files will still be served statically as pre-defined routes.)
+     * If set to true, the plugin will mount around at most
+     * `staticLimit` routes before defaulting to wildcard.
+     * If false, all routes will go under the wildcard route,
+     * with the exclusion of any HTML files bundled by Bun.
      */
     alwaysStatic?: boolean
     /**
@@ -37,7 +40,7 @@ export interface StaticOptions<Prefix extends string> {
     ignorePatterns?: Array<string | RegExp>
 
     /**
-     * Indicate if file extension is required
+     * Indicates if file extension is required in URL request
      *
      * Only works if `alwaysStatic` is set to true
      *
@@ -60,9 +63,6 @@ export interface StaticOptions<Prefix extends string> {
      * @default true
      *
      * If set to false, browser caching will be disabled
-     *
-     * On Bun, if set to false, performance will be significantly improved
-     * as it can be inline as a static resource
      */
     etag?: boolean
 
@@ -99,7 +99,7 @@ export interface StaticOptions<Prefix extends string> {
     /**
      * @default true
      *
-     * Enable serving of index.html as default / route
+     * If set to true, any index.html file served at https://host.com/**\/index.html will also be served at https://host.com/**
      */
     indexHTML?: boolean
 
@@ -127,6 +127,9 @@ export interface StaticOptions<Prefix extends string> {
      */
     decodeURI?: boolean
 
+    /**
+     * specify OpenAPI spec configuration for static routes
+     */
     detail?: DocumentDecoration | ((path: string) => DocumentDecoration)
 
     /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -719,7 +719,7 @@ describe('Static Plugin', () => {
     })
 
     it('serves index.html from cache with content-type and cache headers', async () => {
-        const app = new Elysia().use(staticPlugin())
+        const app = new Elysia().use(staticPlugin({ bunFullstack: false }))
 
         await app.modules
 
@@ -741,7 +741,7 @@ describe('Static Plugin', () => {
     })
 
     it('returns 304 for cached index.html default route', async () => {
-        const app = new Elysia().use(staticPlugin())
+        const app = new Elysia().use(staticPlugin({ bunFullstack: false }))
 
         await app.modules
 
@@ -857,7 +857,8 @@ describe('Static Plugin', () => {
                     assets: 'public',
                     prefix: '',
                     indexHTML: true,
-                    alwaysStatic
+                    alwaysStatic,
+                    bunFullstack: false
                 })
             )
 


### PR DESCRIPTION
If `bunFullstack` isn't set, the `bundleHTML` parameter is used instead, which defaults to true. (this preserves previous behavior)

closes #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `bundleHTML` option is now deprecated; use `bunFullstack` instead
  * `bunFullstack` takes precedence when both options are specified
  * Updated documented default behavior for HTML bundling configuration

* **Refactor**
  * Improved option handling for Bun fullstack HTML bundling behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia-static/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->