### PR TITLE
fix: 2.0.0-exp.0 fails to load on install (undeclared fast-decode-uri-component, removed elysia internals)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
             "require": "./dist/types.js"
         }
     },
+    "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+    },
     "devDependencies": {
         "@elysia/node": "^2.0.0-exp.0",
         "@types/bun": "^1.3.14",
@@ -58,7 +61,6 @@
         "elysia": "^2.0.0-exp.23",
         "esbuild-fix-imports-plugin": "^1.0.23",
         "eslint": "9.6.0",
-        "fast-decode-uri-component": "^1.0.1",
         "tinybench": "^6.0.1",
         "tsdown": "^0.22.3",
         "tsx": "^4.21.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import {
 import type { StaticOptions } from './types'
 import { BunFile, HTMLBundle } from 'bun'
 import { Stats } from 'fs'
-import { MethodMap } from 'elysia/constants'
 
 interface CachedFile {
     data: Blob
@@ -146,12 +145,9 @@ export async function staticPlugin<const Prefix extends string = '/prefix'>({
     }
 
     if (
-        // @ts-ignore private property
-        // !(`GET_${prefix}/*` in app.routeTree) &&
         !alwaysStatic &&
-        app.history?.find(
-            ([method, path]) =>
-                MethodMap['GET'] === method && path === `${prefix}/*`
+        app.routes?.find(
+            (route) => route.method === 'GET' && route.path === `${prefix}/*`
         ) === undefined
     ) {
         mountRoute({


### PR DESCRIPTION
This PR fixes two independent issues that make `@elysia/static@2.0.0-exp.0` fail at import time on any consumer install:

```
Cannot find module './node_modules/fast-decode-uri-component/index.mjs'
  from '.../node_modules/@elysia/static/dist/index.mjs'
```

Reproducible in an empty project with `bun i elysia@2.0.0-exp.42 @elysia/static@2.0.0-exp.0` — both the ESM and CJS entries fail the same way.

## 1. `fast-decode-uri-component` is only a devDependency

The `unbundle: true` build externalizes it **by relative path** (`./node_modules/fast-decode-uri-component/...`) because it isn't a runtime dependency — that path isn't in the published tarball, and consumers never install the package (1.x wasn't affected because the old build inlined it). Moving it to `dependencies` makes tsdown externalize it by bare specifier:

```diff
- import { require_fast_decode_uri_component } from "./node_modules/fast-decode-uri-component/index.mjs";
+ import fastDecodeURI from "fast-decode-uri-component";
```

## 2. Built against elysia internals removed during the exp series

With issue 1 shimmed away, the ESM entry still fails to link against current exp:

```
Export named 'MethodMap' not found in module '.../elysia/dist/constants.mjs'.
```

`src/index.ts` imports `MethodMap` from `elysia/constants` and reads `app.history`, both removed in current 2.0 exp, while the peer range allows `>= 2.0.0-exp.23`. Replaced with the `app.routes` declarations, which have the same `{ method, path }` shape across the supported range (verified on exp.23 and exp.42):

```ts
app.routes?.find(
    (route) => route.method === 'GET' && route.path === `${prefix}/*`
) === undefined
```

## Validation

- `bun test`: 141 pass / 0 fail on this branch (lockfile's exp.23)
- `npm pack` of this branch installed into a clean project on `elysia@2.0.0-exp.42`: the plugin now loads and serves files, with `fast-decode-uri-component` installed automatically as a regular dependency
- happy to attach the minimal reproduction (3 scripts, clean directory) if useful
